### PR TITLE
Add description column

### DIFF
--- a/db/migrate/20170628130449_add_description_to_nodes.rb
+++ b/db/migrate/20170628130449_add_description_to_nodes.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToNodes < ActiveRecord::Migration
+  def change
+    add_column :nodes, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,15 +11,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170628001650) do
+ActiveRecord::Schema.define(version: 20170628130449) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "nodes", force: :cascade do |t|
     t.string  "title"
-    t.boolean "complete?", default: false
+    t.boolean "complete?",   default: false
     t.integer "parent_id"
+    t.text    "description"
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,17 +7,17 @@
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
 3.times do |node|
-  Node.create(title: Faker::Hacker.say_something_smart)
+  Node.create(title: Faker::Hacker.say_something_smart, description: Faker::TwinPeaks.quote)
 end
 
 3.times do |node|
-  Node.create(title: Faker::Hacker.say_something_smart, parent_id: 1)
+  Node.create(title: Faker::Hacker.say_something_smart, parent_id: 1, description: Faker::TwinPeaks.quote)
 end
 
 3.times do |node|
-  Node.create(title: Faker::Hacker.say_something_smart, parent_id: 2)
+  Node.create(title: Faker::Hacker.say_something_smart, parent_id: 2, description: Faker::TwinPeaks.quote)
 end
 
 3.times do |node|
-  Node.create(title: Faker::Hacker.say_something_smart, parent_id: 3)
+  Node.create(title: Faker::Hacker.say_something_smart, parent_id: 3, description: Faker::TwinPeaks.quote)
 end


### PR DESCRIPTION
This PR adds a `description` column to individual nodes. It's a `text` column, so could be used for posting longer information required for some tasks (additional URLs, other notes, etc.)