### PR TITLE
Add calendar nodes and subtypes.

### DIFF
--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -1,0 +1,3 @@
+class Calendar < Node
+
+end

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -1,9 +1,4 @@
 class Node < ActiveRecord::Base
   belongs_to :parent, class_name: "Node", foreign_key: "parent_id"
   has_many :children, class_name: "Node", foreign_key: "parent_id"
-
-  def complete
-    self.complete = true
-    save
-  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,0 +1,3 @@
+class Project < Node
+
+end

--- a/db/migrate/20170628131951_add_type_to_nodes.rb
+++ b/db/migrate/20170628131951_add_type_to_nodes.rb
@@ -1,0 +1,5 @@
+class AddTypeToNodes < ActiveRecord::Migration
+  def change
+    add_column :nodes, :type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170628130449) do
+ActiveRecord::Schema.define(version: 20170628131951) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 20170628130449) do
     t.boolean "complete?",   default: false
     t.integer "parent_id"
     t.text    "description"
+    t.string  "type"
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,17 +7,27 @@
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
 3.times do |node|
-  Node.create(title: Faker::Hacker.say_something_smart, description: Faker::TwinPeaks.quote)
+  Project.create(title: Faker::Hacker.say_something_smart, description: Faker::TwinPeaks.quote)
 end
 
 3.times do |node|
-  Node.create(title: Faker::Hacker.say_something_smart, parent_id: 1, description: Faker::TwinPeaks.quote)
+  Project.create(title: Faker::Hacker.say_something_smart, parent_id: 1, description: Faker::TwinPeaks.quote)
 end
 
 3.times do |node|
-  Node.create(title: Faker::Hacker.say_something_smart, parent_id: 2, description: Faker::TwinPeaks.quote)
+  Project.create(title: Faker::Hacker.say_something_smart, parent_id: 2, description: Faker::TwinPeaks.quote)
 end
 
 3.times do |node|
-  Node.create(title: Faker::Hacker.say_something_smart, parent_id: 3, description: Faker::TwinPeaks.quote)
+  Project.create(title: Faker::Hacker.say_something_smart, parent_id: 3, description: Faker::TwinPeaks.quote)
+end
+
+year = Calendar.create(title: Date.today.year)
+month = Calendar.create(title: Date.today.month, parent_id: year.id)
+Calendar.create(title: Date.today, parent_id: month.id)
+
+6.times do |count|
+  date = Date.today + count.days
+  month = Calendar.find_or_create_by(title: date.month)
+  Calendar.create(title: date, parent_id: month.id)
 end


### PR DESCRIPTION
This PR assumes we can use the `Node` model to handle both the calendar and larger projects. The thinking being `2017` is a parent of `June` is a parent of `Date.today`. Maybe there's something in the future where these nodes "complete" by the day passing? Anyway, the idea is to set up a calendar/tickler that can run alongside the other functionality. The thinking's still rough, but we could also stack completed stuff on the day it was finished.