### PR TITLE
Add locations.

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,0 +1,4 @@
+class Location < ActiveRecord::Base
+  has_many :nodes, through: :location_nodes
+  has_many :location_nodes, dependent: :destroy
+end

--- a/app/models/location_node.rb
+++ b/app/models/location_node.rb
@@ -1,0 +1,4 @@
+class LocationNode < ActiveRecord::Base
+  belongs_to :location
+  belongs_to :node
+end

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -1,4 +1,6 @@
 class Node < ActiveRecord::Base
   belongs_to :parent, class_name: "Node", foreign_key: "parent_id"
   has_many :children, class_name: "Node", foreign_key: "parent_id"
+  has_many :locations, through: :location_nodes
+  has_many :location_nodes, dependent: :destroy
 end

--- a/db/migrate/20170628175458_add_location_table.rb
+++ b/db/migrate/20170628175458_add_location_table.rb
@@ -1,0 +1,8 @@
+class AddLocationTable < ActiveRecord::Migration
+  def change
+    create_table :locations do |t|
+      t.string :title
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170628175741_add_timestamps_to_nodes.rb
+++ b/db/migrate/20170628175741_add_timestamps_to_nodes.rb
@@ -1,0 +1,6 @@
+class AddTimestampsToNodes < ActiveRecord::Migration
+  def change
+    add_column :nodes, :created_at, :datetime
+    add_column :nodes, :updated_at, :datetime
+  end
+end

--- a/db/migrate/20170628180947_create_location_nodes.rb
+++ b/db/migrate/20170628180947_create_location_nodes.rb
@@ -1,0 +1,10 @@
+class CreateLocationNodes < ActiveRecord::Migration
+  def change
+    create_table :location_nodes do |t|
+      t.references :node
+      t.references :location
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,17 +11,32 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170628131951) do
+ActiveRecord::Schema.define(version: 20170628180947) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "location_nodes", force: :cascade do |t|
+    t.integer  "node_id"
+    t.integer  "location_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  create_table "locations", force: :cascade do |t|
+    t.string   "title"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
   create_table "nodes", force: :cascade do |t|
-    t.string  "title"
-    t.boolean "complete?",   default: false
-    t.integer "parent_id"
-    t.text    "description"
-    t.string  "type"
+    t.string   "title"
+    t.boolean  "complete?",   default: false
+    t.integer  "parent_id"
+    t.text     "description"
+    t.string   "type"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
 end


### PR DESCRIPTION
This PR creates locations and sets up a join table between nodes and locations. This is so in the future individual projects can be tagged as associated with `Work`, `Computer`, `Home`, etc. Then we can display all the active project nodes for a given location when you're at that location.