### PR TITLE
Add order column

### DIFF
--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -3,4 +3,13 @@ class Node < ActiveRecord::Base
   has_many :children, class_name: "Node", foreign_key: "parent_id"
   has_many :locations, through: :location_nodes
   has_many :location_nodes, dependent: :destroy
+
+  after_create :add_order
+
+  def add_order
+    if order.nil? && parent.present?
+      self.order = parent.children.length
+      self.save
+    end
+  end
 end

--- a/db/migrate/20170706234400_add_order_column_to_nodes.rb
+++ b/db/migrate/20170706234400_add_order_column_to_nodes.rb
@@ -1,0 +1,5 @@
+class AddOrderColumnToNodes < ActiveRecord::Migration
+  def change
+    add_column :nodes, :order, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170628180947) do
+ActiveRecord::Schema.define(version: 20170706234400) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,6 +37,7 @@ ActiveRecord::Schema.define(version: 20170628180947) do
     t.string   "type"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "order"
   end
 
 end


### PR DESCRIPTION
This PR adds the ability to order nodes. Probably at some point the `Calendar` nodes should be updated to `Calendar#add_order` by the date, but this might just work as-is.