### PR TITLE
Add 5 children by default

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -6,22 +6,25 @@ class ProjectsController < ApplicationController
 
   def new
     @parent_id = params[:parent_id]
-    @project = Project.new
+    @projects = []
+    5.times do
+      @projects << Project.new
+    end
   end
 
   def create
-    @project = Project.new(project_params)
-    unless @project.save
-      flash[:notice] = "Project not created successfully."
-      flash[:color] = "valid"
+    params["projects"].each do |project|
+      if project["title"] != ""
+        Project.create(project_params(project))
+      end
     end
     redirect_to root_path
   end
 
   private
 
-  def project_params
-    params.require(:project).permit(:title, :description, :parent_id)
+  def project_params(my_params)
+    my_params.permit(:title, :description, :parent_id)
   end
 
 end

--- a/app/views/projects/new.haml
+++ b/app/views/projects/new.haml
@@ -1,5 +1,10 @@
-=form_for @project do |f|
-  =f.text_field :title
-  =f.text_field :description
-  =f.hidden_field :parent_id, value: @parent_id
-  =f.submit
+=form_tag projects_path do
+  - @projects.each do |project|
+    =fields_for 'projects[]', project do |p|
+      %ul
+        %li=p.label :title
+        %li=p.text_field :title
+        %li=p.label :description
+        %li=p.text_field :description
+      =p.hidden_field :parent_id, value: @parent_id
+  =submit_tag


### PR DESCRIPTION
This expands the `new` view for Projects to accept up to 5 new child nodes at once. I'd really like to get this to the point where it's easy to keep popping in new form partials as easily as possible.